### PR TITLE
DEVELOP-002: Additional Slack fields, improved results readability

### DIFF
--- a/Ad Feedback Toggle Extension/adtech.js
+++ b/Ad Feedback Toggle Extension/adtech.js
@@ -447,10 +447,6 @@ function tmgLoadAdentify() { //I don't use this myself, better to use your own f
                         {
                             "color": "#36a64f",
                             "fields": [{
-                                    "title": "Reported div and query ID",
-                                    "value": latestFormData.DivIdQueryId
-                                },
-                                {
                                     "title": "Timestamp",
                                     "value": latestFormData.Timestamp
                                 },


### PR DESCRIPTION
- Amended namespace for clickedDiv data. Gathers the query ID now too instead of just the div
- Added two new fields in the Slack output (URL and Query ID inspector)
- Reduced the output of the 'Ad Information Results' to only the reported ads div and query ID. This stops us sending all of the data for previous ads in the same adunit (eg a refreshing unit)

![image](https://github.com/FikretHassan/report-ads-to-slack-chrome-extension/assets/17550385/3eadbd66-df16-4ad4-bc66-f61ef2c906ef)
