### PR TITLE
DEVELOP-007 v2: Remove log for form submission error

### DIFF
--- a/Ad Feedback Toggle Extension/adtech.js
+++ b/Ad Feedback Toggle Extension/adtech.js
@@ -670,6 +670,7 @@ function tmgLoadAdentify() {
 
                         })
                         .catch(error => console.info("Error:", error));
+                        
                         //window.top.adentify.log('latestFormData: ERROR: '+JSON.stringify(error, null, 2));
                 } else {
                     //console.info("Please fill in all fields");

--- a/Ad Feedback Toggle Extension/adtech.js
+++ b/Ad Feedback Toggle Extension/adtech.js
@@ -670,7 +670,7 @@ function tmgLoadAdentify() {
 
                         })
                         .catch(error => console.info("Error:", error));
-                        window.top.adentify.log('latestFormData: ERROR: '+JSON.stringify(error, null, 2));
+                        //window.top.adentify.log('latestFormData: ERROR: '+JSON.stringify(error, null, 2));
                 } else {
                     //console.info("Please fill in all fields");
                 }


### PR DESCRIPTION
Removing the below for now:

`window.top.adentify.log('latestFormData: ERROR: '+JSON.stringify(error, null, 2));`